### PR TITLE
made class names the same for apis with common endpoint

### DIFF
--- a/service/service.py
+++ b/service/service.py
@@ -150,6 +150,9 @@ def list_cart_iterms(customer_id):
 @api.param('customer_id','Customer Identifier')
 @api.param('product_id','Product Identifier')
 class ShopcartItem(Resource):
+    #------------------------------------------------------------------
+    # Retrieve A Shopcart Item 
+    #------------------------------------------------------------------
     @api.doc('get_shopcart_item')
     @api.response(404, 'Item not found')
     def get(self, customer_id, product_id):
@@ -162,6 +165,27 @@ class ShopcartItem(Resource):
         if item:
             return item.serialize(), status.HTTP_200_OK
         api.abort(status.HTTP_404_NOT_FOUND, "Product not in cart")
+
+    #------------------------------------------------------------------
+    # DELETE A Shopcart Item 
+    #------------------------------------------------------------------
+    @api.doc('shopcart_delete')
+    @api.response(204,'Item deleted')
+    def delete(self, customer_id, product_id):
+        """
+        Delete an item from shopcart
+
+        This endpoint will delete a item for the selected product in the shopcart
+        """
+        app.logger.info('Request to delete an existing shopcart item with customer id: %s and product_id: %s',
+                    customer_id, product_id)
+        cart_item = Shopcart.find_by_customer_id_and_product_id(customer_id, product_id)
+
+        if cart_item:
+            app.logger.info('Found item with customer id and product id and it will be deleted')
+            cart_item.delete()
+        # should return 204 whether item is found or not found as discussed in class
+        return make_response('', status.HTTP_204_NO_CONTENT)
         
 
 ######################################################################
@@ -220,33 +244,6 @@ def update_cart_item(customer_id, product_id, requested_quantity=None):
                     customer_id, product_id)
     return make_response(cart_item.serialize(), status.HTTP_200_OK)
 
-######################################################################
-# DELETE A SHOPCART ITEM
-######################################################################
-@api.route('/shopcarts/<int:customer_id>/<int:product_id>',strict_slashes=False)
-@api.param('customer_id','Customer Identifier')
-@api.param('product_id','Product Identifier')
-class ShopcartResource(Resource):
-    #------------------------------------------------------------------
-    # DELETE A Shopcart Item 
-    #------------------------------------------------------------------
-    @api.doc('shopcart_delete')
-    @api.response(204,'Item deleted')
-    def delete(self, customer_id, product_id):
-        """
-        Delete an item from shopcart
-
-        This endpoint will delete a item for the selected product in the shopcart
-        """
-        app.logger.info('Request to delete an existing shopcart item with customer id: %s and product_id: %s',
-                    customer_id, product_id)
-        cart_item = Shopcart.find_by_customer_id_and_product_id(customer_id, product_id)
-
-        if cart_item:
-            app.logger.info('Found item with customer id and product id and it will be deleted')
-            cart_item.delete()
-        # should return 204 whether item is found or not found as discussed in class
-        return make_response('', status.HTTP_204_NO_CONTENT)
 
 ######################################################################
 # MOVE A SHOPCART ITEM TO CHECKOUT

--- a/service/service.py
+++ b/service/service.py
@@ -144,7 +144,7 @@ def list_cart_iterms(customer_id):
         return make_response(jsonify(results), status.HTTP_200_OK)
 
 ######################################################################
-# RETRIEVE AN ITEM
+# RETRIEVE, DELETE
 ######################################################################
 @api.route('/shopcarts/<int:customer_id>/<int:product_id>', strict_slashes=False)
 @api.param('customer_id','Customer Identifier')


### PR DESCRIPTION
get, delete, create, and list api had the common route: @api.route('/shopcarts/<int:customer_id>/<int:product_id>', strict_slashes=False)
but had two different classes coming from merge so I made them be under same class

=> this is necessary for swagger.doc to show all APIs